### PR TITLE
Use link constructs in contacts so they're clickable and stuff.

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -2,9 +2,9 @@
 title: Contacts
 ---
 
-* Our Meetup group: http://www.meetup.com/functional-vilnius/
-* Github organisation: https://github.com/functional-vilnius/
-* Twitter: https://twitter.com/fpvilnius
+* Our Meetup group: [www.meetup.com/functional-vilnius/](http://www.meetup.com/functional-vilnius/)
+* Github organisation: [github.com/functional-vilnius/](https://github.com/functional-vilnius/)
+* Twitter: [@fpvilnius](https://twitter.com/fpvilnius)
 
 Want to get in touch?
 Drop us an email: [info@functionalvilnius.lt](mailto:info@functionalvilnius.lt)


### PR DESCRIPTION
Because selecting and copying stuff on mobile sucks. Also don't mind the typos in meta-stuff.
